### PR TITLE
Add stubs for networking functions; fix minor mistakes in xenonLibAudio.cpp

### DIFF
--- a/dev/src/xenon_launcher/xenonLibAudio.cpp
+++ b/dev/src/xenon_launcher/xenonLibAudio.cpp
@@ -48,8 +48,8 @@ uint64 __fastcall Xbox_XAudioGetVoiceCategoryVolume(uint64 ip, cpu::CpuRegs& reg
 void RegisterXboxAudio(runtime::Symbols& symbols)
 {
 #define REGISTER(x) symbols.RegisterFunction(#x, (runtime::TBlockFunc) &Xbox_##x);
-	REGISTER(XAudioSubmitRenderDriverFrame)
-	REGISTER(XAudioUnregisterRenderDriverClient)
+    REGISTER(XAudioSubmitRenderDriverFrame);
+    REGISTER(XAudioUnregisterRenderDriverClient);
 	REGISTER(XAudioRegisterRenderDriverClient);
 	REGISTER(XAudioGetVoiceCategoryVolume);
 	REGISTER(XAudioGetSpeakerConfig);

--- a/dev/src/xenon_launcher/xenonLibNet.cpp
+++ b/dev/src/xenon_launcher/xenonLibNet.cpp
@@ -1,0 +1,823 @@
+#include "build.h"
+#include "xenonLibNatives.h" 
+#include "xenonLibUtils.h" 
+
+// XNet------------------------------------------------------------------
+
+uint64 __fastcall Xbox_NetDll_XNetCleanup(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetConnect(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetCreateKey(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetDnsLookup(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetDnsRelease(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetGetBroadcastVersionStatus(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetGetConnectStatus(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetGetDebugXnAddr(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetGetEthernetLinkStatus(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetGetOpt(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetGetSystemLinkPort(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetGetTitleXnAddr(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetGetXnAddrPlatform(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetInAddrToServer(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetInAddrToString(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetInAddrToXnAddr(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetQosGetListenStats(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetQosListen(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetQosLookup(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetQosRelease(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetQosServiceLookup(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetRandom(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetRegisterKey(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetReplaceKey(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetServerToInAddr(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetSetSystemLinkPort(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetStartup(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetUnregisterInAddr(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetUnregisterKey(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetXnAddrToInAddr(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XNetXnAddrToMachineId(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XOnlineGetNatType(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+// Winsock---------------------------------------------------------------
+
+uint64 __fastcall Xbox_NetDll_accept(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_bind(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_closesocket(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_connect(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_getpeername(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_getsockname(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_getsockopt(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_htonl(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_htons(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_inet_addr(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_ioctlsocket(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_listen(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_ntohl(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_ntohs(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_recv(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_recvfrom(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_select(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_send(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_sendto(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_setsockopt(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_shutdown(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_socket(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_WSACancelOverlappedIO(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_WSACleanup(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_WSACloseEvent(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_WSACreateEvent(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_WSAEventSelect(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll___WSAFDIsSet(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_WSAGetLastError(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_WSAGetOverlappedResult(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_WSARecv(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_WSARecvFrom(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_WSAResetEvent(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_WSASend(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_WSASendTo(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_WSASetEvent(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_WSASetLastError(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_WSAStartup(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_WSAWaitForMultipleEvents(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+// XRNM ---------------------------------------------------------------------------
+
+uint64 __fastcall Xbox_NetDll_XrnmAllowInboundLinkRequests(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmCancelSends(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmCloseHandle(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmCreateEndpoint(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmCreateInboundLink(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmCreateOutboundLink(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmCreateSendChannel(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmDenyInboundLink(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmFlushSends(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmGetAlertSettings(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmGetAllChannels(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmGetAllLinks(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmGetChannelUserData(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmGetDefaultChannelComponents(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmGetEndpointFromLink(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmGetEvent(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmGetHandleStatus(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmGetHandleUserData(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmGetLocalAddressForEndpoint(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmGetOpt(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmGetRemoteAddressForLink(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmQueryInfo(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmReturnEvent(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmSend(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmSetAlertSettings(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmSetChannelUserData(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmSetHandleUserData(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmSetOpt(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmTerminateLink(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XrnmTerminateSendChannel(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+// QNet ---------------------------------------------------------------------------
+
+uint64 __fastcall Xbox_NetDll_QNetCreateUsingXAudio2(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+// XHttp --------------------------------------------------------------------------
+
+uint64 __fastcall Xbox_NetDll_XHttpCloseHandle(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XHttpConnect(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XHttpCrackUrl(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XHttpCreateUrl(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XHttpDoWork(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XHttpOpen(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XHttpOpenRequest(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XHttpQueryHeaders(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XHttpQueryOption(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XHttpReadData(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XHttpReceiveResponse(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XHttpSendRequest(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XHttpSetOption(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XHttpSetStatusCallback(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XHttpShutdown(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XHttpStartup(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XHttpWriteData(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+// XAuth --------------------------------------------------------------------------
+
+uint64 __fastcall Xbox_NetDll_XAuthFreeToken(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XAuthGetRelyingPartyId(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XAuthGetToken(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XAuthInsecureSocketsAllowed(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XAuthShutdown(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XAuthStartup(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+// XJSON --------------------------------------------------------------------------
+
+uint64 __fastcall Xbox_NetDll_XJSONDestroy(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XJSONGetTokenValue(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XJSONInitialize(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XJSONReadToken(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+uint64 __fastcall Xbox_NetDll_XJSONSetBuffer(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+// Endpoint discovery--------------------------------------------------------------
+
+uint64 __fastcall Xbox_NetDll_XGetServiceEndpoint(uint64 ip, cpu::CpuRegs& regs)
+{
+    RETURN_DEFAULT();
+}
+
+//---------------------------------------------------------------------------------
+
+void RegisterXboxNetworking(runtime::Symbols& symbols)
+{
+#define REGISTER(x) symbols.RegisterFunction(#x, (runtime::TBlockFunc) &Xbox_##x);
+    // XNet --
+    REGISTER(NetDll_XNetCleanup);
+    REGISTER(NetDll_XNetConnect);
+    REGISTER(NetDll_XNetCreateKey);
+    REGISTER(NetDll_XNetDnsLookup);
+    REGISTER(NetDll_XNetDnsRelease);
+    REGISTER(NetDll_XNetGetBroadcastVersionStatus);
+    REGISTER(NetDll_XNetGetConnectStatus);
+    REGISTER(NetDll_XNetGetDebugXnAddr);
+    REGISTER(NetDll_XNetGetEthernetLinkStatus);
+    REGISTER(NetDll_XNetGetOpt);
+    REGISTER(NetDll_XNetGetSystemLinkPort);
+    REGISTER(NetDll_XNetGetTitleXnAddr);
+    REGISTER(NetDll_XNetGetXnAddrPlatform);
+    REGISTER(NetDll_XNetInAddrToServer);
+    REGISTER(NetDll_XNetInAddrToString);
+    REGISTER(NetDll_XNetInAddrToXnAddr);
+    REGISTER(NetDll_XNetQosGetListenStats);
+    REGISTER(NetDll_XNetQosListen);
+    REGISTER(NetDll_XNetQosLookup);
+    REGISTER(NetDll_XNetQosRelease);
+    REGISTER(NetDll_XNetQosServiceLookup);
+    REGISTER(NetDll_XNetRandom);
+    REGISTER(NetDll_XNetRegisterKey);
+    REGISTER(NetDll_XNetReplaceKey);
+    REGISTER(NetDll_XNetServerToInAddr);
+    REGISTER(NetDll_XNetSetSystemLinkPort);
+    REGISTER(NetDll_XNetStartup);
+    REGISTER(NetDll_XNetUnregisterInAddr);
+    REGISTER(NetDll_XNetUnregisterKey);
+    REGISTER(NetDll_XNetXnAddrToInAddr);
+    REGISTER(NetDll_XNetXnAddrToMachineId);
+    REGISTER(NetDll_XOnlineGetNatType);
+    // Winsock --
+    REGISTER(NetDll_accept);
+    REGISTER(NetDll_bind);
+    REGISTER(NetDll_closesocket);
+    REGISTER(NetDll_connect);
+    REGISTER(NetDll_getpeername);
+    REGISTER(NetDll_getsockname);
+    REGISTER(NetDll_getsockopt);
+    REGISTER(NetDll_htonl);
+    REGISTER(NetDll_htons);
+    REGISTER(NetDll_inet_addr);
+    REGISTER(NetDll_ioctlsocket);
+    REGISTER(NetDll_listen);
+    REGISTER(NetDll_ntohl);
+    REGISTER(NetDll_ntohs);
+    REGISTER(NetDll_recv);
+    REGISTER(NetDll_recvfrom);
+    REGISTER(NetDll_select);
+    REGISTER(NetDll_send);
+    REGISTER(NetDll_sendto);
+    REGISTER(NetDll_setsockopt);
+    REGISTER(NetDll_shutdown);
+    REGISTER(NetDll_socket);
+    REGISTER(NetDll_WSACancelOverlappedIO);
+    REGISTER(NetDll_WSACleanup);
+    REGISTER(NetDll_WSACloseEvent);
+    REGISTER(NetDll_WSACreateEvent);
+    REGISTER(NetDll_WSAEventSelect);
+    REGISTER(NetDll___WSAFDIsSet);
+    REGISTER(NetDll_WSAGetLastError);
+    REGISTER(NetDll_WSAGetOverlappedResult);
+    REGISTER(NetDll_WSARecv);
+    REGISTER(NetDll_WSARecvFrom);
+    REGISTER(NetDll_WSAResetEvent);
+    REGISTER(NetDll_WSASend);
+    REGISTER(NetDll_WSASendTo);
+    REGISTER(NetDll_WSASetEvent);
+    REGISTER(NetDll_WSASetLastError);
+    REGISTER(NetDll_WSAStartup);
+    REGISTER(NetDll_WSAWaitForMultipleEvents);
+    // XRNM --
+    REGISTER(NetDll_XrnmAllowInboundLinkRequests);
+    REGISTER(NetDll_XrnmCancelSends);
+    REGISTER(NetDll_XrnmCloseHandle);
+    REGISTER(NetDll_XrnmCreateEndpoint);
+    REGISTER(NetDll_XrnmCreateInboundLink);
+    REGISTER(NetDll_XrnmCreateOutboundLink);
+    REGISTER(NetDll_XrnmCreateSendChannel);
+    REGISTER(NetDll_XrnmDenyInboundLink);
+    REGISTER(NetDll_XrnmFlushSends);
+    REGISTER(NetDll_XrnmGetAlertSettings);
+    REGISTER(NetDll_XrnmGetAllChannels);
+    REGISTER(NetDll_XrnmGetAllLinks);
+    REGISTER(NetDll_XrnmGetChannelUserData);
+    REGISTER(NetDll_XrnmGetDefaultChannelComponents);
+    REGISTER(NetDll_XrnmGetEndpointFromLink);
+    REGISTER(NetDll_XrnmGetEvent);
+    REGISTER(NetDll_XrnmGetHandleStatus);
+    REGISTER(NetDll_XrnmGetHandleUserData);
+    REGISTER(NetDll_XrnmGetLocalAddressForEndpoint);
+    REGISTER(NetDll_XrnmGetOpt);
+    REGISTER(NetDll_XrnmGetRemoteAddressForLink);
+    REGISTER(NetDll_XrnmQueryInfo);
+    REGISTER(NetDll_XrnmReturnEvent);
+    REGISTER(NetDll_XrnmSend);
+    REGISTER(NetDll_XrnmSetAlertSettings);
+    REGISTER(NetDll_XrnmSetChannelUserData);
+    REGISTER(NetDll_XrnmSetHandleUserData);
+    REGISTER(NetDll_XrnmSetOpt);
+    REGISTER(NetDll_XrnmTerminateLink);
+    REGISTER(NetDll_XrnmTerminateSendChannel);
+    // QNet --
+    REGISTER(NetDll_QNetCreateUsingXAudio2);
+    // XHttp --
+    REGISTER(NetDll_XHttpCloseHandle);
+    REGISTER(NetDll_XHttpConnect);
+    REGISTER(NetDll_XHttpCrackUrl);
+    REGISTER(NetDll_XHttpCreateUrl);
+    REGISTER(NetDll_XHttpDoWork);
+    REGISTER(NetDll_XHttpOpen);
+    REGISTER(NetDll_XHttpOpenRequest);
+    REGISTER(NetDll_XHttpQueryHeaders);
+    REGISTER(NetDll_XHttpQueryOption);
+    REGISTER(NetDll_XHttpReadData);
+    REGISTER(NetDll_XHttpReceiveResponse);
+    REGISTER(NetDll_XHttpSendRequest);
+    REGISTER(NetDll_XHttpSetOption);
+    REGISTER(NetDll_XHttpSetStatusCallback);
+    REGISTER(NetDll_XHttpShutdown);
+    REGISTER(NetDll_XHttpStartup);
+    REGISTER(NetDll_XHttpWriteData);
+    // XAuth --
+    REGISTER(NetDll_XAuthFreeToken);
+    REGISTER(NetDll_XAuthGetRelyingPartyId);
+    REGISTER(NetDll_XAuthGetToken);
+    REGISTER(NetDll_XAuthInsecureSocketsAllowed);
+    REGISTER(NetDll_XAuthShutdown);
+    REGISTER(NetDll_XAuthStartup);
+    // XJSON --
+    REGISTER(NetDll_XJSONDestroy);
+    REGISTER(NetDll_XJSONGetTokenValue);
+    REGISTER(NetDll_XJSONInitialize);
+    REGISTER(NetDll_XJSONReadToken);
+    REGISTER(NetDll_XJSONSetBuffer);
+    // Endpoint Discovery --
+    REGISTER(NetDll_XGetServiceEndpoint);
+#undef REGISTER
+}
+
+//---------------------------------------------------------------------------

--- a/dev/src/xenon_launcher/xenonPlatform.cpp
+++ b/dev/src/xenon_launcher/xenonPlatform.cpp
@@ -146,7 +146,7 @@ namespace xenon
 		GLog.Log("Runtime: Initializing Xenon kernel");
 		m_kernel = new Kernel(nativeSystems, commandline);
 
-		// create file syste
+		// create file system
 		GLog.Log("Runtime: Initializing Xenon file system");
 		m_fileSys = new FileSystem(m_kernel, nativeSystems.m_fileSystem, commandline);
 
@@ -163,7 +163,7 @@ namespace xenon
 		m_users = new UserProfileManager();
 
 		// create the audio system
-		GLog.Log("Runtime: Initializing Audio system");
+		GLog.Log("Runtime: Initializing Xenon audio system");
 		m_audio = new Audio(symbols, commandline);
 
 		// initialize config data
@@ -189,6 +189,8 @@ namespace xenon
 		RegisterXboxXAM(symbols);
 		extern void RegisterXboxAudio(runtime::Symbols& symbols);
 		RegisterXboxAudio(symbols);
+        extern void RegisterXboxNetworking(runtime::Symbols& symbols);
+        RegisterXboxNetworking(symbols);
 
 		// register the process native data
 

--- a/dev/src/xenon_launcher/xenon_launcher.vcxproj
+++ b/dev/src/xenon_launcher/xenon_launcher.vcxproj
@@ -131,6 +131,7 @@
     <ClCompile Include="xenonLibFiles.cpp" />
     <ClCompile Include="xenonLibInput.cpp" />
     <ClCompile Include="xenonLibNatives.cpp" />
+    <ClCompile Include="xenonLibNet.cpp" />
     <ClCompile Include="xenonLibThreads.cpp" />
     <ClCompile Include="xenonLibUtils.cpp" />
     <ClCompile Include="xenonLibVideo.cpp" />

--- a/dev/src/xenon_launcher/xenon_launcher.vcxproj.filters
+++ b/dev/src/xenon_launcher/xenon_launcher.vcxproj.filters
@@ -176,6 +176,7 @@
     <ClCompile Include="xenonAudio.cpp">
       <Filter>devices\audio</Filter>
     </ClCompile>
+    <ClCompile Include="xenonLibNet.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="xenonLibUtils.h">


### PR DESCRIPTION
There were a few typos I found in xenonLibPlatform, fixed those along with missing semicolons in xenonLibAudio.