### PR TITLE
Fix arg parsing bug; minor changes to project files

### DIFF
--- a/dev/src/recompiler_api/recompiler_api.vcxproj
+++ b/dev/src/recompiler_api/recompiler_api.vcxproj
@@ -39,6 +39,9 @@
     <IntDir>$(SolutionDir)..\..\_temp\$(Configuration)\$(ProjectName)\</IntDir>
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/dev/src/recompiler_core/internalUtils.h
+++ b/dev/src/recompiler_core/internalUtils.h
@@ -208,8 +208,6 @@ class RECOMPILER_API Commandline
 public:
 	Commandline();
 	Commandline(const char** argv, const int argc);
-	Commandline(const wchar_t** argv, const int argc);
-	Commandline(const wchar_t* cmd);
 
 	/// do we have an option specified ?
 	const bool HasOption(const char* name) const;
@@ -231,7 +229,6 @@ private:
 	TOptions	m_options;
 
 	void AddOption(const std::string& name, const std::wstring& value);
-	void Parse(const wchar_t* cmdLine);
 };
 //---------------------------------------------------------------------------
 

--- a/dev/src/recompiler_tools/recompiler_tools.vcxproj
+++ b/dev/src/recompiler_tools/recompiler_tools.vcxproj
@@ -39,6 +39,9 @@
     <IntDir>$(SolutionDir)..\..\_temp\$(Configuration)\$(ProjectName)\</IntDir>
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(SolutionDir)..\external\wxWidgets-3.1.0\include;$(SolutionDir)..\external\wxWidgets-3.1.0\include\msvc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/dev/src/recompiler_tools/treelistctrl.cpp
+++ b/dev/src/recompiler_tools/treelistctrl.cpp
@@ -3222,7 +3222,7 @@ wxTreeItemId wxTreeListMainWindow::FindItem (const wxTreeItemId& item, int colum
 
     // start checking the next items
     wxString itemText;
-    int col, col_start, col_end;
+    int col = 0, col_start = 0, col_end = 0;
     if (column >= 0) { col_start = col_end = col; }
     else { col_start = 0; col_end = GetColumnCount() - 1; }
     while (next.IsOk() && (next != item)) {

--- a/dev/src/xenon_decompiler/xenon_decompiler.vcxproj
+++ b/dev/src/xenon_decompiler/xenon_decompiler.vcxproj
@@ -39,6 +39,9 @@
     <OutDir>$(SolutionDir)..\..\_bin\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\..\_temp\$(Configuration)\$(ProjectName)\</IntDir>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/dev/src/xenon_launcher/xenon_launcher.vcxproj
+++ b/dev/src/xenon_launcher/xenon_launcher.vcxproj
@@ -37,6 +37,9 @@
     <OutDir>$(SolutionDir)..\..\_bin\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\..\_temp\$(Configuration)\$(ProjectName)\</IntDir>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <Link>
       <OutputFile>$(TargetDir)$(ProjectName)$(TargetExt)</OutputFile>


### PR DESCRIPTION
Ignore the changes to the .vcxproj files - I changed a linker option to reduce warnings during build time.

The actual change is in the code for parsing command line arguments (issue #23), which is weirdly in `internalUtils.cpp`, a part of the `Commandline` class. Confusingly enough, this class is also defined in `launcherCommandline.cpp`, but it looks like in this particular case that implementation is not being used. Along with that fix, I deleted unused constructors and methods for that class as well, but I can revert those changes if you think you are going to need them later.